### PR TITLE
chore: Atualizar next.js para a versão canary e refinar a configuração do middleware

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -8,6 +8,8 @@ import { z } from "zod";
 import { userLoginSchema } from "./src/schemas/user-zod-schema";
 import { prismaClient } from "@/adapters/db/prisma";
 
+const isVercelProduction = process.env.VERCEL_ENV === "production";
+
 export const { handlers, signIn, signOut, auth } = NextAuth({
 	adapter: PrismaAdapter(prismaClient),
 	providers: [
@@ -99,7 +101,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 	],
 	pages: {
 		signIn: "/login",
-		error: "/404",
 	},
 	session: {
 		strategy: "jwt",
@@ -134,11 +135,11 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 
 				if (callbackUrl) {
 					return Response.redirect(new URL(callbackUrl, nextUrl.origin));
-				} else if (userRedirectTo) {
-					return Response.redirect(new URL(userRedirectTo, nextUrl.origin));
-				} else {
-					return Response.redirect(new URL("/", nextUrl.origin));
 				}
+				if (userRedirectTo) {
+					return Response.redirect(new URL(userRedirectTo, nextUrl.origin));
+				}
+				return true;
 			}
 			return true;
 		},
@@ -169,12 +170,18 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
 	},
 	cookies: {
 		sessionToken: {
-			name: `next-auth.session-token`,
+			name:
+				process.env.NODE_ENV === "production" && isVercelProduction
+					? "__Secure-next-auth.session-token"
+					: "next-auth.session-token",
 			options: {
 				httpOnly: true,
 				sameSite: "lax",
 				path: "/",
-				secure: process.env.NODE_ENV === "production",
+				secure:
+					isVercelProduction ||
+					(process.env.NODE_ENV === "production" &&
+						process.env.AUTH_FORCE_SECURE_COOKIES === "false"),
 			},
 		},
 	},

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,11 @@
 /** @type {import('next').NextConfig} */
+
 const nextConfig = {
 	images: {
 		unoptimized: true,
+	},
+	experimental: {
+		nodeMiddleware: true,
 	},
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"embla-carousel-react": "^8.6.0",
 				"jsonwebtoken": "^9.0.2",
 				"lucide-react": "^0.513.0",
-				"next": "^15.3.3",
+				"next": "^15.4.2-canary.14",
 				"next-auth": "^5.0.0-beta.28",
 				"nodemailer": "^6.10.1",
 				"react": "^19.1.0",
@@ -142,21 +142,21 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.4.tgz",
-			"integrity": "sha512-A9CnAbC6ARNMKcIcrQwq6HeHCjpcBZ5wSx4U01WXCqEKlrzB9F9315WDNHkrs2xbx7YjjSxbUYxuN6EQzpcY2g==",
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+			"integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.0.3",
+				"@emnapi/wasi-threads": "1.0.4",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.4.tgz",
-			"integrity": "sha512-hHyapA4A3gPaDCNfiqyZUStTMqIkKRshqPIuDOXv1hcBnD4U3l8cP0T1HMCfGRxQ6V64TGCcoswChANyOAwbQg==",
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
+			"integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -164,9 +164,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.3.tgz",
-			"integrity": "sha512-8K5IFFsQqF9wQNJptGbS6FNKgUTsSRYnTqNCG1vPP8jFdjSv18n2mQfJpkt2Oibo9iBEzcDnDxNwKTzC7svlJw==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+			"integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -242,9 +242,9 @@
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-			"integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+			"version": "0.15.1",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+			"integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -292,9 +292,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.30.1",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
-			"integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
+			"version": "9.31.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+			"integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -315,27 +315,14 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-			"integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.4.tgz",
+			"integrity": "sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/core": "^0.15.1",
 				"levn": "^0.4.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-			"integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -950,9 +937,9 @@
 			}
 		},
 		"node_modules/@next/env": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.5.tgz",
-			"integrity": "sha512-7g06v8BUVtN2njAX/r8gheoVffhiKFVt4nx74Tt6G4Hqw9HCLYQVx/GkH2qHvPtAHZaUNZ0VXAa0pQP6v1wk7g==",
+			"version": "15.4.2-canary.14",
+			"resolved": "https://registry.npmjs.org/@next/env/-/env-15.4.2-canary.14.tgz",
+			"integrity": "sha512-xGjb+6SqIs14ICP6wPZm+bljWVS2Sn4sRhP/DnSjwU6Ck65Fq7Jl1zrsQIZJOKGQ+/La5SZoUJIzy3SDJGmZ/g==",
 			"license": "MIT"
 		},
 		"node_modules/@next/eslint-plugin-next": {
@@ -966,9 +953,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-arm64": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.5.tgz",
-			"integrity": "sha512-lM/8tilIsqBq+2nq9kbTW19vfwFve0NR7MxfkuSUbRSgXlMQoJYg+31+++XwKVSXk4uT23G2eF/7BRIKdn8t8w==",
+			"version": "15.4.2-canary.14",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.4.2-canary.14.tgz",
+			"integrity": "sha512-g0BD0peB80ri+w7B2NLLmPcOJ8H55TemyjyozCKpvOlZYjYfMlfOaXMvbVtNBfclxxoGCZRRl16GCZuOax3CcA==",
 			"cpu": [
 				"arm64"
 			],
@@ -982,9 +969,9 @@
 			}
 		},
 		"node_modules/@next/swc-darwin-x64": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.5.tgz",
-			"integrity": "sha512-WhwegPQJ5IfoUNZUVsI9TRAlKpjGVK0tpJTL6KeiC4cux9774NYE9Wu/iCfIkL/5J8rPAkqZpG7n+EfiAfidXA==",
+			"version": "15.4.2-canary.14",
+			"resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.4.2-canary.14.tgz",
+			"integrity": "sha512-Pcs2OxDjDL/mywPqwZGUdl0mRv4ZnpAcU9NVIXroAsXkuGW5EWUqINKeGWLUPrM0UfFH+IvsIewlJKaueuEx1w==",
 			"cpu": [
 				"x64"
 			],
@@ -998,9 +985,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-gnu": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.5.tgz",
-			"integrity": "sha512-LVD6uMOZ7XePg3KWYdGuzuvVboxujGjbcuP2jsPAN3MnLdLoZUXKRc6ixxfs03RH7qBdEHCZjyLP/jBdCJVRJQ==",
+			"version": "15.4.2-canary.14",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.4.2-canary.14.tgz",
+			"integrity": "sha512-syyqkZv1H1Mt8SCT4MtkzOPSF159bf93o/vrjznraveuV5tIuiFAd+ym73MUXmVZqZh2LHnXQeSZ3gd48vaGWg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1014,9 +1001,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-arm64-musl": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.5.tgz",
-			"integrity": "sha512-k8aVScYZ++BnS2P69ClK7v4nOu702jcF9AIHKu6llhHEtBSmM2zkPGl9yoqbSU/657IIIb0QHpdxEr0iW9z53A==",
+			"version": "15.4.2-canary.14",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.4.2-canary.14.tgz",
+			"integrity": "sha512-A+tlBXynjQ2yJthAjP8e8YcuHGVRiG4S+wjQ95OrtbEHlY7HiSnADsc81J82EoEwpWMWGO3tbNJP7x9Tzwlqfg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1030,9 +1017,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-gnu": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.5.tgz",
-			"integrity": "sha512-2xYU0DI9DGN/bAHzVwADid22ba5d/xrbrQlr2U+/Q5WkFUzeL0TDR963BdrtLS/4bMmKZGptLeg6282H/S2i8A==",
+			"version": "15.4.2-canary.14",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.4.2-canary.14.tgz",
+			"integrity": "sha512-9RiDRxZb5Awahs/23r7qbWu6I01U50KW4zjnbuvavFAbnbmihSlXUgmfJbFFAw6giI1SSlrTngw/T/739c6gLg==",
 			"cpu": [
 				"x64"
 			],
@@ -1046,9 +1033,9 @@
 			}
 		},
 		"node_modules/@next/swc-linux-x64-musl": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.5.tgz",
-			"integrity": "sha512-TRYIqAGf1KCbuAB0gjhdn5Ytd8fV+wJSM2Nh2is/xEqR8PZHxfQuaiNhoF50XfY90sNpaRMaGhF6E+qjV1b9Tg==",
+			"version": "15.4.2-canary.14",
+			"resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.4.2-canary.14.tgz",
+			"integrity": "sha512-rXZMEEBpfyIPofiPk4wq8ViChYbQYrAoJwxLnj8H8xQJkwruQiTdtr73QbCI1rjZASuEFcyBisidpTxd8APOiw==",
 			"cpu": [
 				"x64"
 			],
@@ -1062,9 +1049,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-arm64-msvc": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.5.tgz",
-			"integrity": "sha512-h04/7iMEUSMY6fDGCvdanKqlO1qYvzNxntZlCzfE8i5P0uqzVQWQquU1TIhlz0VqGQGXLrFDuTJVONpqGqjGKQ==",
+			"version": "15.4.2-canary.14",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.4.2-canary.14.tgz",
+			"integrity": "sha512-yObs6Nlr7cmM/qteFZdvkuJPz6R4piHTeP6/4AYX5VfPiyEYP5ExVeR66VfZZMpb1N6qKldUHfJhRrkuEbKXmw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1078,9 +1065,9 @@
 			}
 		},
 		"node_modules/@next/swc-win32-x64-msvc": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.5.tgz",
-			"integrity": "sha512-5fhH6fccXxnX2KhllnGhkYMndhOiLOLEiVGYjP2nizqeGWkN10sA9taATlXwake2E2XMvYZjjz0Uj7T0y+z1yw==",
+			"version": "15.4.2-canary.14",
+			"resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.4.2-canary.14.tgz",
+			"integrity": "sha512-aH3PHjF/HVyYGAd+Ey03iVnKaVyznH3+Gc9xfM2sMPrckNhXq0ObeuuAkbF92qA0nS35i9T2GxF8wZVoPqZLzw==",
 			"cpu": [
 				"x64"
 			],
@@ -1151,9 +1138,9 @@
 			}
 		},
 		"node_modules/@pkgr/core": {
-			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
-			"integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1164,9 +1151,9 @@
 			}
 		},
 		"node_modules/@prisma/client": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.11.1.tgz",
-			"integrity": "sha512-5CLFh8QP6KxRm83pJ84jaVCeSVPQr8k0L2SEtOJHwdkS57/VQDcI/wQpGmdyOZi+D9gdNabdo8tj1Uk+w+upsQ==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.12.0.tgz",
+			"integrity": "sha512-wn98bJ3Cj6edlF4jjpgXwbnQIo/fQLqqQHPk2POrZPxTlhY3+n90SSIF3LMRVa8VzRFC/Gec3YKJRxRu+AIGVA==",
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1186,9 +1173,9 @@
 			}
 		},
 		"node_modules/@prisma/config": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.11.1.tgz",
-			"integrity": "sha512-z6rCTQN741wxDq82cpdzx2uVykpnQIXalLhrWQSR0jlBVOxCIkz3HZnd8ern3uYTcWKfB3IpVAF7K2FU8t/8AQ==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.12.0.tgz",
+			"integrity": "sha512-HovZWzhWEMedHxmjefQBRZa40P81N7/+74khKFz9e1AFjakcIQdXgMWKgt20HaACzY+d1LRBC+L4tiz71t9fkg==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1196,53 +1183,53 @@
 			}
 		},
 		"node_modules/@prisma/debug": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.11.1.tgz",
-			"integrity": "sha512-lWRb/YSWu8l4Yum1UXfGLtqFzZkVS2ygkWYpgkbgMHn9XJlMITIgeMvJyX5GepChzhmxuSuiq/MY/kGFweOpGw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.12.0.tgz",
+			"integrity": "sha512-plbz6z72orcqr0eeio7zgUrZj5EudZUpAeWkFTA/DDdXEj28YHDXuiakvR6S7sD6tZi+jiwQEJAPeV6J6m/tEQ==",
 			"devOptional": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/engines": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.11.1.tgz",
-			"integrity": "sha512-6eKEcV6V8W2eZAUwX2xTktxqPM4vnx3sxz3SDtpZwjHKpC6lhOtc4vtAtFUuf5+eEqBk+dbJ9Dcaj6uQU+FNNg==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.12.0.tgz",
+			"integrity": "sha512-4BRZZUaAuB4p0XhTauxelvFs7IllhPmNLvmla0bO1nkECs8n/o1pUvAVbQ/VOrZR5DnF4HED0PrGai+rIOVePA==",
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/debug": "6.11.1",
-				"@prisma/engines-version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
-				"@prisma/fetch-engine": "6.11.1",
-				"@prisma/get-platform": "6.11.1"
+				"@prisma/debug": "6.12.0",
+				"@prisma/engines-version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
+				"@prisma/fetch-engine": "6.12.0",
+				"@prisma/get-platform": "6.12.0"
 			}
 		},
 		"node_modules/@prisma/engines-version": {
-			"version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
-			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9.tgz",
-			"integrity": "sha512-swFJTOOg4tHyOM1zB/pHb3MeH0i6t7jFKn5l+ZsB23d9AQACuIRo9MouvuKGvnDogzkcjbWnXi/NvOZ0+n5Jfw==",
+			"version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
+			"resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc.tgz",
+			"integrity": "sha512-70vhecxBJlRr06VfahDzk9ow4k1HIaSfVUT3X0/kZoHCMl9zbabut4gEXAyzJZxaCGi5igAA7SyyfBI//mmkbQ==",
 			"devOptional": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/@prisma/fetch-engine": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.11.1.tgz",
-			"integrity": "sha512-NBYzmkXTkj9+LxNPRSndaAeALOL1Gr3tjvgRYNqruIPlZ6/ixLeuE/5boYOewant58tnaYFZ5Ne0jFBPfGXHpQ==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.12.0.tgz",
+			"integrity": "sha512-EamoiwrK46rpWaEbLX9aqKDPOd8IyLnZAkiYXFNuq0YsU0Z8K09/rH8S7feOWAVJ3xzeSgcEJtBlVDrajM9Sag==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/debug": "6.11.1",
-				"@prisma/engines-version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
-				"@prisma/get-platform": "6.11.1"
+				"@prisma/debug": "6.12.0",
+				"@prisma/engines-version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
+				"@prisma/get-platform": "6.12.0"
 			}
 		},
 		"node_modules/@prisma/get-platform": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.11.1.tgz",
-			"integrity": "sha512-b2Z8oV2gwvdCkFemBTFd0x4lsL4O2jLSx8lB7D+XqoFALOQZPa7eAPE1NU0Mj1V8gPHRxIsHnyUNtw2i92psUw==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.12.0.tgz",
+			"integrity": "sha512-nRerTGhTlgyvcBlyWgt8OLNIV7QgJS2XYXMJD1hysorMCuLAjuDDuoxmVt7C2nLxbuxbWPp7OuFRHC23HqD9dA==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/debug": "6.11.1"
+				"@prisma/debug": "6.12.0"
 			}
 		},
 		"node_modules/@radix-ui/number": {
@@ -1939,12 +1926,6 @@
 			"integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
 			"license": "MIT"
 		},
-		"node_modules/@swc/counter": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-			"integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-			"license": "Apache-2.0"
-		},
 		"node_modules/@swc/helpers": {
 			"version": "0.5.15",
 			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2363,9 +2344,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.16.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.3.tgz",
-			"integrity": "sha512-sr4Xz74KOUeYadexo1r8imhRtlVXcs+j3XK3TcoiYk7B1t3YRVJgtaD3cwX73NYb71pmVuMLNRhJ9XKdoDB74g==",
+			"version": "22.16.5",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
+			"integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2403,17 +2384,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.36.0.tgz",
-			"integrity": "sha512-lZNihHUVB6ZZiPBNgOQGSxUASI7UJWhT8nHyUGCnaQ28XFCw98IfrMCG3rUl1uwUWoAvodJQby2KTs79UTcrAg==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.38.0.tgz",
+			"integrity": "sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.36.0",
-				"@typescript-eslint/type-utils": "8.36.0",
-				"@typescript-eslint/utils": "8.36.0",
-				"@typescript-eslint/visitor-keys": "8.36.0",
+				"@typescript-eslint/scope-manager": "8.38.0",
+				"@typescript-eslint/type-utils": "8.38.0",
+				"@typescript-eslint/utils": "8.38.0",
+				"@typescript-eslint/visitor-keys": "8.38.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
@@ -2427,7 +2408,7 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.36.0",
+				"@typescript-eslint/parser": "^8.38.0",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <5.9.0"
 			}
@@ -2443,16 +2424,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.36.0.tgz",
-			"integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.38.0.tgz",
+			"integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.36.0",
-				"@typescript-eslint/types": "8.36.0",
-				"@typescript-eslint/typescript-estree": "8.36.0",
-				"@typescript-eslint/visitor-keys": "8.36.0",
+				"@typescript-eslint/scope-manager": "8.38.0",
+				"@typescript-eslint/types": "8.38.0",
+				"@typescript-eslint/typescript-estree": "8.38.0",
+				"@typescript-eslint/visitor-keys": "8.38.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2468,14 +2449,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.36.0.tgz",
-			"integrity": "sha512-JAhQFIABkWccQYeLMrHadu/fhpzmSQ1F1KXkpzqiVxA/iYI6UnRt2trqXHt1sYEcw1mxLnB9rKMsOxXPxowN/g==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.38.0.tgz",
+			"integrity": "sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.36.0",
-				"@typescript-eslint/types": "^8.36.0",
+				"@typescript-eslint/tsconfig-utils": "^8.38.0",
+				"@typescript-eslint/types": "^8.38.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2490,14 +2471,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.36.0.tgz",
-			"integrity": "sha512-wCnapIKnDkN62fYtTGv2+RY8FlnBYA3tNm0fm91kc2BjPhV2vIjwwozJ7LToaLAyb1ca8BxrS7vT+Pvvf7RvqA==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.38.0.tgz",
+			"integrity": "sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.36.0",
-				"@typescript-eslint/visitor-keys": "8.36.0"
+				"@typescript-eslint/types": "8.38.0",
+				"@typescript-eslint/visitor-keys": "8.38.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2508,9 +2489,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.36.0.tgz",
-			"integrity": "sha512-Nhh3TIEgN18mNbdXpd5Q8mSCBnrZQeY9V7Ca3dqYvNDStNIGRmJA6dmrIPMJ0kow3C7gcQbpsG2rPzy1Ks/AnA==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.38.0.tgz",
+			"integrity": "sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2525,14 +2506,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.36.0.tgz",
-			"integrity": "sha512-5aaGYG8cVDd6cxfk/ynpYzxBRZJk7w/ymto6uiyUFtdCozQIsQWh7M28/6r57Fwkbweng8qAzoMCPwSJfWlmsg==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.38.0.tgz",
+			"integrity": "sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.36.0",
-				"@typescript-eslint/utils": "8.36.0",
+				"@typescript-eslint/types": "8.38.0",
+				"@typescript-eslint/typescript-estree": "8.38.0",
+				"@typescript-eslint/utils": "8.38.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.1.0"
 			},
@@ -2549,9 +2531,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.36.0.tgz",
-			"integrity": "sha512-xGms6l5cTJKQPZOKM75Dl9yBfNdGeLRsIyufewnxT4vZTrjC0ImQT4fj8QmtJK84F58uSh5HVBSANwcfiXxABQ==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.38.0.tgz",
+			"integrity": "sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2563,16 +2545,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.36.0.tgz",
-			"integrity": "sha512-JaS8bDVrfVJX4av0jLpe4ye0BpAaUW7+tnS4Y4ETa3q7NoZgzYbN9zDQTJ8kPb5fQ4n0hliAt9tA4Pfs2zA2Hg==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.38.0.tgz",
+			"integrity": "sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.36.0",
-				"@typescript-eslint/tsconfig-utils": "8.36.0",
-				"@typescript-eslint/types": "8.36.0",
-				"@typescript-eslint/visitor-keys": "8.36.0",
+				"@typescript-eslint/project-service": "8.38.0",
+				"@typescript-eslint/tsconfig-utils": "8.38.0",
+				"@typescript-eslint/types": "8.38.0",
+				"@typescript-eslint/visitor-keys": "8.38.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -2648,16 +2630,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.36.0.tgz",
-			"integrity": "sha512-VOqmHu42aEMT+P2qYjylw6zP/3E/HvptRwdn/PZxyV27KhZg2IOszXod4NcXisWzPAGSS4trE/g4moNj6XmH2g==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.38.0.tgz",
+			"integrity": "sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.36.0",
-				"@typescript-eslint/types": "8.36.0",
-				"@typescript-eslint/typescript-estree": "8.36.0"
+				"@typescript-eslint/scope-manager": "8.38.0",
+				"@typescript-eslint/types": "8.38.0",
+				"@typescript-eslint/typescript-estree": "8.38.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2672,13 +2654,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.36.0.tgz",
-			"integrity": "sha512-vZrhV2lRPWDuGoxcmrzRZyxAggPL+qp3WzUrlZD+slFueDiYHxeBa34dUXPuC0RmGKzl4lS5kFJYvKCq9cnNDA==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.38.0.tgz",
+			"integrity": "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.36.0",
+				"@typescript-eslint/types": "8.38.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -3402,17 +3384,6 @@
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/busboy": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-			"integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-			"dependencies": {
-				"streamsearch": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=10.16.0"
-			}
-		},
 		"node_modules/call-bind": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -3968,9 +3939,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.182",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.182.tgz",
-			"integrity": "sha512-Lv65Btwv9W4J9pyODI6EWpdnhfvrve/us5h1WspW8B2Fb0366REPtY3hX7ounk1CkV/TBjWCEvCBBbYbmV0qCA==",
+			"version": "1.5.190",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.190.tgz",
+			"integrity": "sha512-k4McmnB2091YIsdCgkS0fMVMPOJgxl93ltFzaryXqwip1AaxeDqKCGLxkXODDA5Ab/D+tV5EL5+aTx76RvLRxw==",
 			"license": "ISC"
 		},
 		"node_modules/embla-carousel": {
@@ -4218,9 +4189,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.30.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
-			"integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
+			"version": "9.31.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
+			"integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4228,9 +4199,9 @@
 				"@eslint-community/regexpp": "^4.12.1",
 				"@eslint/config-array": "^0.21.0",
 				"@eslint/config-helpers": "^0.3.0",
-				"@eslint/core": "^0.14.0",
+				"@eslint/core": "^0.15.0",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.30.1",
+				"@eslint/js": "9.31.0",
 				"@eslint/plugin-kit": "^0.3.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
@@ -4307,9 +4278,9 @@
 			}
 		},
 		"node_modules/eslint-config-prettier": {
-			"version": "10.1.5",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
-			"integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+			"version": "10.1.8",
+			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -4492,9 +4463,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.5.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.1.tgz",
-			"integrity": "sha512-dobTkHT6XaEVOo8IO90Q4DOSxnm3Y151QxPJlM/vKC0bVy+d6cVWQZLlFiuZPP0wS6vZwSKeJgKkcS+KfMBlRw==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.3.tgz",
+			"integrity": "sha512-NAdMYww51ehKfDyDhv59/eIItUVzU0Io9H2E8nHNGKEeeqlnci+1gCvrHib6EmZdf6GxF+LCV5K7UC65Ezvw7w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4884,9 +4855,9 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-			"integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
@@ -5701,9 +5672,9 @@
 			}
 		},
 		"node_modules/jose": {
-			"version": "6.0.11",
-			"resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
-			"integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+			"version": "6.0.12",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.0.12.tgz",
+			"integrity": "sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -6347,9 +6318,9 @@
 			}
 		},
 		"node_modules/napi-postinstall": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.0.tgz",
-			"integrity": "sha512-M7NqKyhODKV1gRLdkwE7pDsZP2/SC2a2vHkOYh9MCpKMbWVfyVfUw5MaH83Fv6XMjxr5jryUp3IDDL9rlxsTeA==",
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.2.tgz",
+			"integrity": "sha512-tWVJxJHmBWLy69PvO96TZMZDrzmw5KeiZBz3RHmiM2XZ9grBJ2WgMAFVVg25nqp3ZjTFUs2Ftw1JhscL3Teliw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -6370,15 +6341,13 @@
 			"license": "MIT"
 		},
 		"node_modules/next": {
-			"version": "15.3.5",
-			"resolved": "https://registry.npmjs.org/next/-/next-15.3.5.tgz",
-			"integrity": "sha512-RkazLBMMDJSJ4XZQ81kolSpwiCt907l0xcgcpF4xC2Vml6QVcPNXW0NQRwQ80FFtSn7UM52XN0anaw8TEJXaiw==",
+			"version": "15.4.2-canary.14",
+			"resolved": "https://registry.npmjs.org/next/-/next-15.4.2-canary.14.tgz",
+			"integrity": "sha512-OMMToV7aqlKzv2+ewDo8tI1aO9L/01JHbBgIEgW+0LyHUexwYLZIw0pLCsA8aV+0XX7hPYMIZcBYvf+wGpzcRA==",
 			"license": "MIT",
 			"dependencies": {
-				"@next/env": "15.3.5",
-				"@swc/counter": "0.1.3",
+				"@next/env": "15.4.2-canary.14",
 				"@swc/helpers": "0.5.15",
-				"busboy": "1.6.0",
 				"caniuse-lite": "^1.0.30001579",
 				"postcss": "8.4.31",
 				"styled-jsx": "5.1.6"
@@ -6390,19 +6359,19 @@
 				"node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
 			},
 			"optionalDependencies": {
-				"@next/swc-darwin-arm64": "15.3.5",
-				"@next/swc-darwin-x64": "15.3.5",
-				"@next/swc-linux-arm64-gnu": "15.3.5",
-				"@next/swc-linux-arm64-musl": "15.3.5",
-				"@next/swc-linux-x64-gnu": "15.3.5",
-				"@next/swc-linux-x64-musl": "15.3.5",
-				"@next/swc-win32-arm64-msvc": "15.3.5",
-				"@next/swc-win32-x64-msvc": "15.3.5",
-				"sharp": "^0.34.1"
+				"@next/swc-darwin-arm64": "15.4.2-canary.14",
+				"@next/swc-darwin-x64": "15.4.2-canary.14",
+				"@next/swc-linux-arm64-gnu": "15.4.2-canary.14",
+				"@next/swc-linux-arm64-musl": "15.4.2-canary.14",
+				"@next/swc-linux-x64-gnu": "15.4.2-canary.14",
+				"@next/swc-linux-x64-musl": "15.4.2-canary.14",
+				"@next/swc-win32-arm64-msvc": "15.4.2-canary.14",
+				"@next/swc-win32-x64-msvc": "15.4.2-canary.14",
+				"sharp": "^0.34.3"
 			},
 			"peerDependencies": {
 				"@opentelemetry/api": "^1.1.0",
-				"@playwright/test": "^1.41.2",
+				"@playwright/test": "^1.51.1",
 				"babel-plugin-react-compiler": "*",
 				"react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
 				"react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
@@ -6479,9 +6448,9 @@
 			}
 		},
 		"node_modules/node-addon-api": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.4.0.tgz",
-			"integrity": "sha512-D9DI/gXHvVmjHS08SVch0Em8G5S1P+QWtU31appcKT/8wFSPRcdHadIFSAntdMMVM5zz+/DL+bL/gz3UDppqtg==",
+			"version": "8.5.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+			"integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
 			"license": "MIT",
 			"engines": {
 				"node": "^18 || ^20 || >= 21"
@@ -6523,9 +6492,9 @@
 			}
 		},
 		"node_modules/oauth4webapi": {
-			"version": "3.5.5",
-			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.5.5.tgz",
-			"integrity": "sha512-1K88D2GiAydGblHo39NBro5TebGXa+7tYoyIbxvqv3+haDDry7CBE1eSYuNbOSsYCCU6y0gdynVZAkm4YPw4hg==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.6.0.tgz",
+			"integrity": "sha512-OwXPTXjKPOldTpAa19oksrX9TYHA0rt+VcUFTkJ7QKwgmevPpNm9Cn5vFZUtIo96FiU6AfPuUUGzoXqgOzibWg==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
@@ -6883,15 +6852,15 @@
 			}
 		},
 		"node_modules/prisma": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/prisma/-/prisma-6.11.1.tgz",
-			"integrity": "sha512-VzJToRlV0s9Vu2bfqHiRJw73hZNCG/AyJeX+kopbu4GATTjTUdEWUteO3p4BLYoHpMS4o8pD3v6tF44BHNZI1w==",
+			"version": "6.12.0",
+			"resolved": "https://registry.npmjs.org/prisma/-/prisma-6.12.0.tgz",
+			"integrity": "sha512-pmV7NEqQej9WjizN6RSNIwf7Y+jeh9mY1JEX2WjGxJi4YZWexClhde1yz/FuvAM+cTwzchcMytu2m4I6wPkIzg==",
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@prisma/config": "6.11.1",
-				"@prisma/engines": "6.11.1"
+				"@prisma/config": "6.12.0",
+				"@prisma/engines": "6.12.0"
 			},
 			"bin": {
 				"prisma": "build/index.js"
@@ -7601,14 +7570,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/streamsearch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-			"engines": {
-				"node": ">=10.0.0"
-			}
-		},
 		"node_modules/string.prototype.includes": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -7795,13 +7756,13 @@
 			}
 		},
 		"node_modules/synckit": {
-			"version": "0.11.8",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
-			"integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+			"version": "0.11.11",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+			"integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@pkgr/core": "^0.2.4"
+				"@pkgr/core": "^0.2.9"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -7902,9 +7863,9 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8065,15 +8026,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.36.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.36.0.tgz",
-			"integrity": "sha512-fTCqxthY+h9QbEgSIBfL9iV6CvKDFuoxg6bHPNpJ9HIUzS+jy2lCEyCmGyZRWEBSaykqcDPf1SJ+BfCI8DRopA==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.38.0.tgz",
+			"integrity": "sha512-FsZlrYK6bPDGoLeZRuvx2v6qrM03I0U0SnfCLPs/XCCPCFD80xU9Pg09H/K+XFa68uJuZo7l/Xhs+eDRg2l3hg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.36.0",
-				"@typescript-eslint/parser": "8.36.0",
-				"@typescript-eslint/utils": "8.36.0"
+				"@typescript-eslint/eslint-plugin": "8.38.0",
+				"@typescript-eslint/parser": "8.38.0",
+				"@typescript-eslint/typescript-estree": "8.38.0",
+				"@typescript-eslint/utils": "8.38.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"embla-carousel-react": "^8.6.0",
 		"jsonwebtoken": "^9.0.2",
 		"lucide-react": "^0.513.0",
-		"next": "^15.3.3",
+		"next": "^15.4.2-canary.14",
 		"next-auth": "^5.0.0-beta.28",
 		"nodemailer": "^6.10.1",
 		"react": "^19.1.0",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,11 @@ import { NextResponse } from "next/server";
 
 import { auth } from "../auth";
 
+export const config = {
+	matcher: ["/((?!api|_next/static|_next/image|favicon.ico|assets).*)"],
+	runtime: "nodejs",
+};
+
 const ROTAS_PUBLICAS = [
 	"/login",
 	"/desenvolvedores",
@@ -87,7 +92,3 @@ export default auth((req) => {
 
 	return NextResponse.next();
 });
-
-export const config = {
-	matcher: ["/((?!api|_next/static|_next/image|favicon.ico|assets).*)"],
-};


### PR DESCRIPTION
- Atualizar a dependência next.js da versão 15.3.3 para 15.4.2-canary.14.
- Aprimorar a configuração do middleware definindo o tempo de execução como "nodejs" e garantindo que ele corresponda a todas as rotas, exceto para API e ativos estáticos.